### PR TITLE
R-Lab: replace placeholder projects with Vio, Byunron, RYutility

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,14 +1,19 @@
-- name: "ChartAI"
+- name: "Vio"
   status: "In Development"
-  description: "AI-powered SOAP note generator for TCM practitioners. Converts shorthand clinical notes into insurance-compliant medical documentation."
-  tech_stack: ["Python", "OpenAI API", "JaneApp Integration", "NLP"]
-  image: "/assets/images/project-chartai.jpg" # Placeholder or need generation
-  demo_url: "#"
-  github_url: "https://github.com/jasonpa/chart-ai"
-  slug: "chart-ai"
+  description: "Patient voice charting app."
+  tech_stack: ["Swift"]
+  slug: "vio"
 
-- name: "HerbBase"
-  status: "Planning"
-  description: "Digital materia medica database with interaction checking and modern search capabilities."
-  tech_stack: ["React", "Node.js", "MongoDB"]
-  slug: "herb-base"
+- name: "Byunron"
+  status: "In Development"
+  description: "Korean-first AI sparring tool for licensed TCM practitioners (한의사). Practitioners submit their own anonymized case narratives — AI challenges their clinical reasoning across 8 structured layers, and reasoning is saved as a \"commit log\" personal library."
+  tech_stack: ["TypeScript"]
+  slug: "byunron"
+
+- name: "RYutility"
+  status: "Live"
+  description: "Running pace calculator with VDOT-based training zones and Current/Target comparison."
+  tech_stack: ["HTML", "JavaScript"]
+  demo_url: "https://ryutility.com"
+  github_url: "https://github.com/jasonpa/ryutility"
+  slug: "ryutility"

--- a/_pages/lab.md
+++ b/_pages/lab.md
@@ -39,11 +39,18 @@ permalink: /lab/
             {% endfor %}
           </div>
           {% endif %}
-          {% if project.github_url %}
-          <a href="{{ project.github_url }}" style="font-family:var(--latin-ui);font-size:12px;font-weight:600;color:var(--brand);display:inline-flex;align-items:center;gap:6px;">
-            <i class="fab fa-github"></i> View Repository
-          </a>
-          {% endif %}
+          <div style="display:flex;flex-wrap:wrap;gap:16px;">
+            {% if project.demo_url and project.demo_url != "#" %}
+            <a href="{{ project.demo_url }}" target="_blank" rel="noopener" style="font-family:var(--latin-ui);font-size:12px;font-weight:600;color:var(--brand);display:inline-flex;align-items:center;gap:6px;">
+              <i class="fas fa-arrow-up-right-from-square"></i> View Live
+            </a>
+            {% endif %}
+            {% if project.github_url %}
+            <a href="{{ project.github_url }}" style="font-family:var(--latin-ui);font-size:12px;font-weight:600;color:var(--brand);display:inline-flex;align-items:center;gap:6px;">
+              <i class="fab fa-github"></i> View Repository
+            </a>
+            {% endif %}
+          </div>
         </div>
       </div>
       {% endfor %}


### PR DESCRIPTION
## Summary
- Replace placeholder projects (ChartAI, HerbBase) in R-Lab with real active projects: Vio, Byunron, RYutility
- Vio: patient voice charting app (Swift, In Development, private repo)
- Byunron: Korean-first AI sparring tool for licensed TCM practitioners (TypeScript, In Development, private repo)
- RYutility: VDOT-based running pace calculator (HTML/JS, Live, public repo + demo link)
- Add "View Live" link rendering in lab.md template for projects with a demo_url

## Test plan
- [x] `bundle exec jekyll build` succeeds
- [x] Verified rendered _site/lab/index.html shows all three project cards with correct links